### PR TITLE
Add browserify-shim to deps instead of dev-deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "browserify": "^13.0.0",
-    "browserify-shim": "^3.8.12",
     "del": "^1.2.1",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.1.1",
@@ -39,6 +38,7 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
+    "browserify-shim": "^3.8.12",
     "react": "^0.14.7"
   },
   "babel": {


### PR DESCRIPTION
I installed react-ghost-i18n with `npm install --save react-ghost-i18n`, and I got the error:

```
15 02 2016 11:17:42.717:ERROR [framework.browserify]: Error: Cannot find module 'browserify-shim' from '…/node_modules/react-ghost-i18n'
```

I figured out that `browserify-shim` was not installed automatically by the package.
Adding it to `dependencies` fixes the problem.
However, maybe it should be added to `peerDependencies` instead?
